### PR TITLE
Improve coverage of sqlParseVariablesImpl()

### DIFF
--- a/DBI.Rproj
+++ b/DBI.Rproj
@@ -12,6 +12,9 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -97,7 +97,7 @@ setGeneric("sqlParseVariables", function(con, sql, ...) {
 setMethod("sqlParseVariables", "DBIConnection", function(con, sql, ...) {
   sqlParseVariablesImpl(sql,
     list(
-      sqlQuoteSpec('"', "'"),
+      sqlQuoteSpec('"', '"'),
       sqlQuoteSpec("'", "'")
     ),
     list(

--- a/src/sqldelim.cpp
+++ b/src/sqldelim.cpp
@@ -19,7 +19,7 @@ namespace {
 	template <class T>
 	bool hasPrefix(T begin, T end, const std::string& prefix) {
 		if (prefix.size() == 0) {
-			return false;
+			return false; // # nocov
 		}
 
 		if (end - begin < prefix.size()) {
@@ -74,7 +74,7 @@ namespace {
 				break;
 			default:
 				assert(false);
-				return false;
+				return false; // # nocov
 			}
 		}
 

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -45,3 +45,30 @@ test_that("escaping quotes with doubling works", {
     SQL("'this is a single '' one ?quoted string' 42 ")
   )
 })
+
+test_that("corner cases work", {
+  expect_equal(
+    sqlInterpolate(ANSI(), ""),
+    SQL("")
+  )
+  expect_equal(
+    sqlInterpolate(ANSI(), "?"),
+    SQL("?")
+  )
+  expect_equal(
+    sqlInterpolate(ANSI(), "?a", a = 1),
+    SQL("1")
+  )
+  expect_equal(
+    sqlInterpolate(ANSI(), "\"\""),
+    SQL("\"\"")
+  )
+  expect_equal(
+    sqlInterpolate(ANSI(), "?a\"\"?b", a = 1, b = 2),
+    SQL("1\"\"2")
+  )
+  expect_equal(
+    sqlInterpolate(ANSI(), "--"),
+    SQL("--")
+  )
+})

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -51,9 +51,9 @@ test_that("corner cases work", {
     sqlInterpolate(ANSI(), ""),
     SQL("")
   )
-  expect_equal(
+  expect_error(
     sqlInterpolate(ANSI(), "?"),
-    SQL("?")
+    "Length 0 variable"
   )
   expect_equal(
     sqlInterpolate(ANSI(), "?a", a = 1),

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -63,6 +63,10 @@ test_that("corner cases work", {
     sqlInterpolate(ANSI(), "\"\""),
     SQL("\"\"")
   )
+  expect_error(
+    sqlInterpolate(ANSI(), "\""),
+    "Unterminated literal"
+  )
   expect_equal(
     sqlInterpolate(ANSI(), "?a\"\"?b", a = 1, b = 2),
     SQL("1\"\"2")
@@ -70,5 +74,25 @@ test_that("corner cases work", {
   expect_equal(
     sqlInterpolate(ANSI(), "--"),
     SQL("--")
+  )
+  expect_error(
+    sqlInterpolate(ANSI(), "/*"),
+    "Unterminated comment"
+  )
+
+  # Test escaping rules
+  expect_identical(
+    sqlParseVariablesImpl(
+      "?a '?b\\'?c' ?d '''' ?e",
+      list(
+        sqlQuoteSpec("'", "'", escape = "\\", doubleEscape = FALSE)
+      ),
+      list(
+      )
+    ),
+    list(
+      start = c(1L, 13L, 21L),
+      end = c(2L, 14L, 22L)
+    )
   )
 })

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -30,6 +30,18 @@ test_that("strings are quoted", {
     sqlInterpolate(ANSI(), "?a", a = "abc"),
     SQL("'abc'")
   )
+})
 
+test_that("some more complex case works as well", {
+  expect_equal(
+    sqlInterpolate(ANSI(), "asdf ?faa /*fdsa'zsc' */ qwer 'wer' \"bnmvbn\" -- Zc \n '234' ?fuu -- bar", faa = "abc", fuu=42L),
+    SQL("asdf 'abc' /*fdsa'zsc' */ qwer 'wer' \"bnmvbn\" -- Zc \n '234' 42 -- bar")
+  )
+})
 
+test_that("escaping quotes with doubling works", {
+  expect_equal(
+    sqlInterpolate(ANSI(), "'this is a single '' one ?quoted string' ?bar ", bar=42),
+    SQL("'this is a single '' one ?quoted string' 42 ")
+  )
 })

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -34,8 +34,8 @@ test_that("strings are quoted", {
 
 test_that("some more complex case works as well", {
   expect_equal(
-    sqlInterpolate(ANSI(), "asdf ?faa /*fdsa'zsc' */ qwer 'wer' \"bnmvbn\" -- Zc \n '234' ?fuu -- bar", faa = "abc", fuu=42L),
-    SQL("asdf 'abc' /*fdsa'zsc' */ qwer 'wer' \"bnmvbn\" -- Zc \n '234' 42 -- bar")
+    sqlInterpolate(ANSI(), "asdf ?faa /*fdsa'zsc' */ qwer 'wer' \"bnmvbn\" -- Zc \n '234' ?fuu -- ?bar", faa = "abc", fuu=42L),
+    SQL("asdf 'abc' /*fdsa'zsc' */ qwer 'wer' \"bnmvbn\" -- Zc \n '234' 42 -- ?bar")
   )
 })
 


### PR DESCRIPTION
Isolated tests from #83.

Local coverage of sqldelim.cpp is at 93%.