### PR TITLE
Require R >= 3.0.0 (using 'slots' argument of setClass())

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(
     person("Kirill", "Müller", email = "krlmlr+r@mailbox.org", role = c("aut", "cre"))
     )
 Depends:
-    R (>= 2.15.0),
+    R (>= 3.0.0),
     methods
 Suggests:
     covr,


### PR DESCRIPTION
Package installation fails on R < 3.0.0, tested on R 2.15.2.