### PR TITLE
Add generic dbIsReadOnly

### DIFF
--- a/R/DBObject.R
+++ b/R/DBObject.R
@@ -107,6 +107,24 @@ setGeneric("dbIsValid",
   def = function(dbObj, ...) standardGeneric("dbIsValid"),
   valueClass = "logical")
 
+#' Is this DBMS object read only?
+#'
+#' This generic tests whether a database object is read only.
+#'
+#' @inheritParams dbGetInfo
+#' @family DBIDriver generics
+#' @family DBIConnection generics
+#' @family DBIResult generics
+#' @export
+#' @examples
+#' dbIsReadOnly(RSQLite::SQLite())
+#'
+#' con <- dbConnect(RSQLite::SQLite(), ":memory:", flags = SQLITE_RO)
+#' dbIsReadOnly(con)
+setGeneric("dbIsReadOnly",
+  def = function(dbObj, ...) standardGeneric("dbIsReadOnly"),
+  valueClass = "logical")
+
 setGeneric("summary")
 setMethod("summary", "DBIObject", function(object, ...) {
   info <- dbGetInfo(dbObj = object, ...)


### PR DESCRIPTION
From Issue #189 

> Users that use a read-only mode would likely want a way to periodically check whether their connection is truly read only.
> 
> For my own backend, I've added this generic, but want to suggest this feature here. I can contribute a PR if there is interest.